### PR TITLE
Rename AssociatePublicIPAddress Parameter to be more accurate

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -469,7 +469,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   JvmHeapOverride:
     Default: ''

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -35,9 +35,9 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - AvailabilityZones
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - SSLCertificateARN
       - Label:
@@ -85,8 +85,6 @@ Metadata:
           - QSS3KeyPrefix
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       AvailabilityZones:
         default: Availability Zones
       CatalinaOpts:
@@ -151,6 +149,8 @@ Metadata:
         default: SSH key name
       HostedZone:
         default: Route 53 Hosted Zone
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       JvmHeapOverride:
         default: Confluence Heap Size Override
       JvmHeapOverrideSynchrony:
@@ -195,12 +195,6 @@ Metadata:
         default: Quick Start S3 Key Prefix
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address.
-    Type: String
   CatalinaOpts:
     Default: ''
     Description: Pass in any additional JVM options to tune Catalina Tomcat.
@@ -471,6 +465,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
     Description: (Optional) The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Type: String
   JvmHeapOverride:
     Default: ''
     Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g.
@@ -709,7 +709,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
 
         # NOTE: This is set to default due to CF parameter limits.
         AutologinCookieAge: ''

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -34,8 +34,8 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - SSLCertificateARN
       - Label:
@@ -87,8 +87,6 @@ Metadata:
           - QSS3KeyPrefix
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       AutologinCookieAge:
         default: Remember Me cookie expiry
       CatalinaOpts:
@@ -153,6 +151,8 @@ Metadata:
         default: SSH key name
       HostedZone:
         default: Route 53 Hosted Zone
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       JvmHeapOverride:
         default: Confluence Heap Size Override
       JvmHeapOverrideSynchrony:
@@ -197,12 +197,6 @@ Metadata:
         default: Quick Start S3 Key Prefix
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address.
-    Type: String
   AutologinCookieAge:
     Default: ''
     Description: Sets the Remember Me (autologin) cookie expiry length in seconds. If blank this defaults to 1 year.
@@ -477,6 +471,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing Route53 Hosted Zone.
     Description: (Optional) The domain name of the Route53 PRIVATE Hosted Zone in which to create cnames.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Type: String
   JvmHeapOverride:
     Default: ''
     Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig; e.g., 1024m or 1g.
@@ -695,7 +695,7 @@ Conditions:
   UseHostedZone:
     !Not [!Equals [!Ref HostedZone, '']]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
   UseSubDomainName:
     !Not [!Equals [!Ref SubDomainName, '']]
   UseSynchronyAutoScalingGroup:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -475,7 +475,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   JvmHeapOverride:
     Default: ''


### PR DESCRIPTION
Before this parameter said it made the EC2 instances publicly accessible which isn't true. It simply determines whether the load balancer is internet facing or internal. This is now more clear.