### PR TITLE
Bump atlassian services version which has updated version of aurora

### DIFF
--- a/ci/quickstart-confluence-master-parms.json
+++ b/ci/quickstart-confluence-master-parms.json
@@ -4,10 +4,6 @@
         "ParameterValue": "$[taskcat_genaz_2]"
     },
     {
-        "ParameterKey": "AssociatePublicIpAddress",
-        "ParameterValue": "false"
-    },
-    {
         "ParameterKey": "DBMasterUserPassword",
         "ParameterValue": "$[taskcat_genpass_8S]"
     },


### PR DESCRIPTION
The version of atlassian services we are using right now doesn't have the latest version of Aurora template which is causing all aurora deploys to fail. This bumps the version which has the necessary parameter group to support postgres 9.6.12