### PR TITLE
DCD-534: Switch default collaborative editing mode to synchrony-local

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -315,12 +315,12 @@ Parameters:
     Description: Size of cluster node root volume in GB (note - size based upon Application indexes x 4).
     Type: Number
   CollaborativeEditingMode:
-    Default: synchrony-separate-nodes
+    Default: synchrony-local
     AllowedValues:
       - none
       - synchrony-local
       - synchrony-separate-nodes
-    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (leave 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
+    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
     Default: '6.13.5'

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -321,12 +321,12 @@ Parameters:
     Description: Size of cluster node root volume in GB (note - size based upon Application indexes x 4).
     Type: Number
   CollaborativeEditingMode:
-    Default: synchrony-separate-nodes
+    Default: synchrony-local
     AllowedValues:
       - none
       - synchrony-local
       - synchrony-separate-nodes
-    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (leave 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
+    Description: Collaborative Editing can be off, run locallly on the Confluence nodes (requires Confluence version 6.12+ and 1 GB heap free for Synchrony), or run on a separately autoscaled group of nodes.
     Type: String
   ConfluenceVersion:
     Default: '6.13.5'


### PR DESCRIPTION
The local managed Synchrony is the preferred setup and we should keep synchrony-separate-nodes only for backward compatibility purposes. If that is the case, we should switch the default to synchrony-local and include a note in the documentation that if you are running Confluence prior 6.12 you need to explicitly select synchrony-separate-nodes.

Link to the recommendation:

https://confluence.atlassian.com/doc/possible-confluence-and-synchrony-configurations-958779064.html#PossibleConfluenceandSynchronyConfigurations-PossibleconfigurationsforConfluenceDataCenter