### PR TITLE
DCD-528: Update ASI to disable event subscription

### DIFF
--- a/ci/quickstart-confluence-aurora.json
+++ b/ci/quickstart-confluence-aurora.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-confluence/"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.r4.large"
+  }
+]

--- a/ci/quickstart-confluence-master-parms.json
+++ b/ci/quickstart-confluence-master-parms.json
@@ -1,46 +1,46 @@
 [
-    {
-        "ParameterKey": "AvailabilityZones",
-        "ParameterValue": "$[taskcat_genaz_2]"
-    },
-    {
-        "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
-    },
-    {
-        "ParameterKey": "DBMultiAZ",
-        "ParameterValue": "false"
-    },
-    {
-        "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
-    },
-    {
-        "ParameterKey": "DBStorage",
-        "ParameterValue": "100"
-    },
-    {
-        "ParameterKey": "DBStorageType",
-        "ParameterValue": "Provisioned IOPS"
-    },
-    {
-        "ParameterKey": "CustomDnsName",
-        "ParameterValue": "qs-conf-ci.awsqs.com"
-    },
-    {
-        "ParameterKey":"CidrBlock",
-        "ParameterValue":"10.0.0.0/16"
-    },
-    {
-        "ParameterKey":"QSS3BucketName",
-        "ParameterValue":"$[taskcat_autobucket]"
-    },
-    {
-        "ParameterKey":"QSS3KeyPrefix",
-        "ParameterValue":"quickstart-atlassian-confluence/"
-    },
-    {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    }
+  {
+    "ParameterKey": "AvailabilityZones",
+    "ParameterValue": "$[taskcat_genaz_2]"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "DBStorage",
+    "ParameterValue": "100"
+  },
+  {
+    "ParameterKey": "DBStorageType",
+    "ParameterValue": "Provisioned IOPS"
+  },
+  {
+    "ParameterKey": "CustomDnsName",
+    "ParameterValue": "qs-conf-ci.awsqs.com"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-confluence/"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  }
 ]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -16,9 +16,17 @@ global:
     - us-west-2
   reporting: true
 
+# By default we are running only single test. By uncommenting additional tests, you can run different scenarios.
+# Taskcat currently doesn't support scenario selection.
 tests:
   confluence:
     parameter_input: quickstart-confluence-master-parms.json
     template_file: quickstart-confluence-master-with-vpc.template.yaml
     regions:
      - us-east-1
+
+#  confluence-aurora:
+#    parameter_input: quickstart-confluence-aurora.json
+#    template_file: quickstart-confluence-master.template.yaml
+#    regions:
+#      - ap-southeast-2


### PR DESCRIPTION
Updates ASI submodule to disable event subscription by default.

More context: atlassian/quickstart-atlassian-services#9