### PR TITLE
DCD-289: Fix linting

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+templates:
+  - templates/*

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1104,7 +1104,6 @@ Resources:
     DependsOn:
       - EFSMountAz1
       - EFSMountAz2
-      - DB
     Metadata:
       AWS::CloudFormation::Init:
         config:
@@ -1222,7 +1221,6 @@ Resources:
           Ebs:
             VolumeSize: !Ref ClusterNodeVolumeSize
         - DeviceName: /dev/xvdf
-          Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref ConfluenceClusterNodeInstanceProfile
@@ -1318,7 +1316,6 @@ Resources:
     DependsOn:
       - EFSMountAz1
       - EFSMountAz2
-      - DB
     Metadata:
       AWS::CloudFormation::Init:
         config:
@@ -1406,7 +1403,7 @@ Resources:
               command: /opt/atlassian/bin/clone_deployment_repo
               ignoreErrors: true
             080_run_atl_init_node:
-              command: !Sub |
+              command:
                 cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local aws_confluence_synchrony_node.yml /var/log/ansible-bootstrap.log
               ignoreErrors: true
 
@@ -1414,7 +1411,6 @@ Resources:
       AssociatePublicIpAddress: false
       BlockDeviceMappings:
         - DeviceName: /dev/xvdf
-          Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref ConfluenceClusterNodeInstanceProfile


### PR DESCRIPTION
Linting ouput before:

```
W3005 Obsolete DependsOn on resource (DB), dependency already enforced by a "Fn:GetAtt" at Resources/ClusterNodeLaunchConfig/Metadata/AWS::CloudFormation::Init/config/files//etc/atl/content/Fn::Join/1/23/Fn::Sub/1/DBEndpointAddress/Fn::GetAtt/['DB', 'Outputs', 'RDSEndPointAddress']
templates/quickstart-confluence-master.template.yaml:1107:9

W3005 Obsolete DependsOn on resource (DB), dependency already enforced by a "Fn:GetAtt" at Resources/ClusterNodeLaunchConfig/Metadata/AWS::CloudFormation::Init/config/files//etc/atl/content/Fn::Join/1/29/Fn::Sub/1/DBEndpointPort/Fn::GetAtt/['DB', 'Outputs', 'RDSEndPointPort']
templates/quickstart-confluence-master.template.yaml:1107:9

E2523 Only one of [VirtualName, Ebs, NoDevice] should be specified for Resources/ClusterNodeLaunchConfig/Properties/BlockDeviceMappings/1
templates/quickstart-confluence-master.template.yaml:1224:11

W3005 Obsolete DependsOn on resource (DB), dependency already enforced by a "Fn:GetAtt" at Resources/SynchronyClusterNodeLaunchConfig/Metadata/AWS::CloudFormation::Init/config/files//etc/atl/content/Fn::Join/1/21/Fn::Sub/1/DBEndpointAddress/Fn::GetAtt/['DB', 'Outputs', 'RDSEndPointAddress']
templates/quickstart-confluence-master.template.yaml:1321:9

W3005 Obsolete DependsOn on resource (DB), dependency already enforced by a "Fn:GetAtt" at Resources/SynchronyClusterNodeLaunchConfig/Metadata/AWS::CloudFormation::Init/config/files//etc/atl/content/Fn::Join/1/22/Fn::Sub/1/DBEndpointPort/Fn::GetAtt/['DB', 'Outputs', 'RDSEndPointPort']
templates/quickstart-confluence-master.template.yaml:1321:9

W1020 Fn::Sub isn't needed because there are no variables at Resources/SynchronyClusterNodeLaunchConfig/Metadata/AWS::CloudFormation::Init/config/commands/080_run_atl_init_node/command/Fn::Sub
templates/quickstart-confluence-master.template.yaml:1409:15

E2523 Only one of [VirtualName, Ebs, NoDevice] should be specified for Resources/SynchronyClusterNodeLaunchConfig/Properties/BlockDeviceMappings/0
templates/quickstart-confluence-master.template.yaml:1416:11
```

Build results:
https://server-syd-bamboo.internal.atlassian.com/browse/ZDCD-AWSCONFLUENCE5-2