### PR TITLE
Add configuration for an HTTPS build on bamboo

### DIFF
--- a/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
@@ -1,0 +1,50 @@
+[
+    {
+        "ParameterKey": "InternetFacingLoadBalancer",
+        "ParameterValue": "true"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "f925dO1ry_"
+    },
+    {
+        "ParameterKey": "DBStorage",
+        "ParameterValue": "100"
+    },
+    {
+        "ParameterKey": "DBStorageType",
+        "ParameterValue": "Provisioned IOPS"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "CustomDnsName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "SSLCertificateARN",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    },
+    {
+        "ParameterKey": "ClusterNodeInstanceType",
+        "ParameterValue": "t3.medium"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t3.medium"
+    }
+]

--- a/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
@@ -45,6 +45,6 @@
     },
     {
         "ParameterKey": "DBInstanceClass",
-        "ParameterValue": "db.t3.medium"
+        "ParameterValue": "db.t2.medium"
     }
 ]

--- a/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-confluence-ci-params.json
@@ -45,6 +45,6 @@
     },
     {
         "ParameterKey": "DBInstanceClass",
-        "ParameterValue": "db.t2.medium"
+        "ParameterValue": "db.t3.medium"
     }
 ]

--- a/ci/params/ssl-and-dns/taskcat.yml
+++ b/ci/params/ssl-and-dns/taskcat.yml
@@ -1,0 +1,13 @@
+---
+global:
+  marketplace-ami: false
+  owner: dc-deployments-syd@atlassian.com
+  qsname: quickstart-atlassian-confluence
+  regions:
+    - us-east-1
+  reporting: true
+
+tests:
+  confluence:
+    parameter_input: params/ssl-and-dns/quickstart-confluence-ci-params.json
+    template_file: quickstart-confluence-master.template.yaml

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -343,18 +343,34 @@ Parameters:
   DBInstanceClass:
     Default: db.m4.large
     AllowedValues:
+      - db.m5.large
+      - db.m5.xlarge
+      - db.m5.2xlarge
+      - db.m5.4xlarge
+      - db.m5.12xlarge
+      - db.m5.24xlarge
       - db.m4.large
       - db.m4.xlarge
       - db.m4.2xlarge
       - db.m4.4xlarge
       - db.m4.10xlarge
       - db.m4.16xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge
       - db.r4.4xlarge
       - db.r4.8xlarge
       - db.r4.16xlarge
+      - db.t3.medium
+      - db.t3.large
+      - db.t3.xlarge
+      - db.t3.2xlarge
       - db.t2.medium
       - db.t2.large
       - db.t2.xlarge

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -346,18 +346,34 @@ Parameters:
   DBInstanceClass:
     Default: db.m4.large
     AllowedValues:
+      - db.m5.large
+      - db.m5.xlarge
+      - db.m5.2xlarge
+      - db.m5.4xlarge
+      - db.m5.12xlarge
+      - db.m5.24xlarge
       - db.m4.large
       - db.m4.xlarge
       - db.m4.2xlarge
       - db.m4.4xlarge
       - db.m4.10xlarge
       - db.m4.16xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
       - db.r4.large
       - db.r4.xlarge
       - db.r4.2xlarge
       - db.r4.4xlarge
       - db.r4.8xlarge
       - db.r4.16xlarge
+      - db.t3.medium
+      - db.t3.large
+      - db.t3.xlarge
+      - db.t3.2xlarge
       - db.t2.medium
       - db.t2.large
       - db.t2.xlarge


### PR DESCRIPTION
I've added an SSL parameter set which can be used with the newest version of the bamboo build (specs PR pending). I've also added the latest database types that are supported by the `quickstart-database-for-atlassian-services template`.