### PR TITLE
DCD-691: add arch mapping for c4.large EC2 instance type

### DIFF
--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -733,7 +733,7 @@ Mappings:
   AWSInstanceType2Arch:
     c4.large:
       Arch: HVM64
-      Jvmheap: 4608m
+      Jvmheap: 2304m
     c4.xlarge:
       Arch: HVM64
       Jvmheap: 4608m

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -731,6 +731,9 @@ Conditions:
     !Equals [!Ref DBEngine, "PostgreSQL"]
 Mappings:
   AWSInstanceType2Arch:
+    c4.large:
+      Arch: HVM64
+      Jvmheap: 4608m
     c4.xlarge:
       Arch: HVM64
       Jvmheap: 4608m


### PR DESCRIPTION
Noticed this while deploying a test environment and trying to use a smaller instance type. Corresponding Jira PR: https://github.com/atlassian/quickstart-atlassian-jira/pull/38