### PR TITLE
DCD-961: fixed KeyPairName parameter

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -517,8 +517,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances. 
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   MailEnabled:
     AllowedValues:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -524,7 +524,7 @@ Parameters:
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: List<AWS::EC2::Keypair>
+    Type: String
     Default: ''
   MailEnabled:
     AllowedValues:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -524,7 +524,7 @@ Parameters:
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   MailEnabled:
     AllowedValues:


### PR DESCRIPTION
When deploying with an ASI, the KeyPairName is always required. When deploying into an existing ASI, you have the option to just use that ASI's key pair. This corrects the description for the parameter in both templates.

Also, the type is now a drop-down list (it used to be a simple String).