### PR TITLE
DCD-954: Add exported bastion IP to EC2 security group on port 22

### DIFF
--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1759,6 +1759,14 @@ Resources:
           ToPort: 8091
           CidrIp: !Ref CidrBlock
         - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp:
+            !Sub
+              - "${BastionIp}/32"
+              - BastionIp:
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+        - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp:


### PR DESCRIPTION
Imports the private IP of the bastion host from the ASI so that when `CidrBlock` is set the Bastion can still SSH to the webserver.

See [This PR](https://github.com/atlassian/quickstart-atlassian-services/pull/31) for more context.