### PR TITLE
If KeyPair does not exist dont use it

### DIFF
--- a/ci/params/no-bastion/quickstart-confluence-no-bastion.json
+++ b/ci/params/no-bastion/quickstart-confluence-no-bastion.json
@@ -1,0 +1,54 @@
+[
+  {
+    "ParameterKey": "AvailabilityZones",
+    "ParameterValue": "$[taskcat_genaz_2]"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "DBStorage",
+    "ParameterValue": "100"
+  },
+  {
+    "ParameterKey": "DBStorageType",
+    "ParameterValue": "Provisioned IOPS"
+  },
+  {
+    "ParameterKey": "CustomDnsName",
+    "ParameterValue": "qs-conf-ci.awsqs.com"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "10.0.0.0/16"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-confluence/"
+  },
+  {
+    "ParameterKey": "CollaborativeEditingMode",
+    "ParameterValue": "synchrony-separate-nodes"
+  },
+  {
+    "ParameterKey": "ExportPrefix",
+    "ParameterValue": "$[taskcat_random-string]"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/no-bastion/taskcat.yml
+++ b/ci/params/no-bastion/taskcat.yml
@@ -1,0 +1,14 @@
+global:
+  marketplace-ami: false
+  owner: quickstart-eng@amazon.com
+  qsname: quickstart-atlassian-confluence
+  regions:
+    - ap-northeast-2
+  reporting: true
+
+tests:
+  confluence:
+    parameter_input: params/no-bastion/quickstart-confluence-no-bastion.json
+    template_file: quickstart-confluence-master-with-vpc.template.yaml
+    regions:
+     - ap-northeast-2

--- a/ci/quickstart-confluence-master-parms.json
+++ b/ci/quickstart-confluence-master-parms.json
@@ -46,5 +46,9 @@
   {
     "ParameterKey": "ExportPrefix",
     "ParameterValue": "$[taskcat_random-string]"
+  },
+  {
+    "ParameterKey": "CollaborativeEditingMode",
+    "ParameterValue": "synchrony-separate-nodes"
   }
 ]

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1163,10 +1163,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
+          Value: "COMMIT: 5a5830b11d9fa3db7ef0bfb9ba5f565f1e732115"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
+          Value: "TIMESTAMP: 2020-08-18T21:56:03Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1612,9 +1612,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
+          Value: "COMMIT: 5a5830b11d9fa3db7ef0bfb9ba5f565f1e732115"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
+          Value: "TIMESTAMP: 2020-08-18T21:56:03Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1699,9 +1699,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
+          Value: "COMMIT: 5a5830b11d9fa3db7ef0bfb9ba5f565f1e732115"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
+          Value: "TIMESTAMP: 2020-08-18T21:56:03Z"
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -1784,9 +1784,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
+          Value: "COMMIT: 5a5830b11d9fa3db7ef0bfb9ba5f565f1e732115"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
+          Value: "TIMESTAMP: 2020-08-18T21:56:03Z"
     DependsOn:
       - LoadBalancer
   SynchronyTargetGroup:
@@ -1894,9 +1894,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
+          Value: "COMMIT: 5a5830b11d9fa3db7ef0bfb9ba5f565f1e732115"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
+          Value: "TIMESTAMP: 2020-08-18T21:56:03Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1163,10 +1163,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 2801c601f146bfee744534882ab5f6c6bbec8dc9"
+          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-07T07:20:53Z"
+          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1530,7 +1530,7 @@ Resources:
       KeyName: !If
         - KeyProvided
         - !Ref KeyPairName
-        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
+        - Ref: AWS::NoValue
       IamInstanceProfile: !Ref ConfluenceClusterNodeInstanceProfile
       ImageId:
         !FindInMap
@@ -1612,9 +1612,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 2801c601f146bfee744534882ab5f6c6bbec8dc9"
+          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-07T07:20:53Z"
+          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1699,9 +1699,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 2801c601f146bfee744534882ab5f6c6bbec8dc9"
+          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-07T07:20:53Z"
+          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -1784,9 +1784,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 2801c601f146bfee744534882ab5f6c6bbec8dc9"
+          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-07T07:20:53Z"
+          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
     DependsOn:
       - LoadBalancer
   SynchronyTargetGroup:
@@ -1894,9 +1894,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 2801c601f146bfee744534882ab5f6c6bbec8dc9"
+          Value: "COMMIT: 037699b5e165f04b3b4aace9b81cece619539a1f"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-07T07:20:53Z"
+          Value: "TIMESTAMP: 2020-08-18T11:13:14Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:


### PR DESCRIPTION
Missed this logic for `SynchronyClusterNodeGroup` when doing the original Bastion optionality work