### PR TITLE
DCD-1434: Removed version 9 from DBEngineVersion

### DIFF
--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -353,9 +353,10 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9
       - 10
       - 11
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
     Type: String
   DBInstanceClass:
     Default: db.m4.large

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -356,7 +356,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m4.large

--- a/templates/quickstart-confluence-master-with-vpc.template.yaml
+++ b/templates/quickstart-confluence-master-with-vpc.template.yaml
@@ -353,7 +353,6 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -366,9 +366,10 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9
       - 10
       - 11
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
     Type: String
   DBInstanceClass:
     Default: db.m4.large

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -366,7 +366,6 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected."

--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -369,7 +369,7 @@ Parameters:
       - 9
       - 10
       - 11
-    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. Warning: Amazon RDS for PostgreSQL 9.6 will reach EOL on January 18, 2022. If this is initial deployment DO NOT choose 9. If you wish to upgrade major version from 9 to upper version see: https://confluence.atlassian.com/confkb/manually-upgrading-the-postgresql-version-of-your-amazon-rds-database-from-9-6-to-10-1097172180.html"
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Confluence version you're installing supports the database engine selected. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m4.large


### PR DESCRIPTION
Remove Postgres version 9 as the version will be EOL 
