### PR TITLE
DCD-956 Creation policy to wait until all the instances are up and running

### DIFF
--- a/templates/quickstart-confluence-master.template.yaml
+++ b/templates/quickstart-confluence-master.template.yaml
@@ -1157,6 +1157,10 @@ Resources:
   # Confluence node config
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref ClusterNodeMin
+        Timeout: PT15M
     Properties:
       DesiredCapacity: !Ref ClusterNodeMin
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig


### PR DESCRIPTION
DCD-956 Creation policy to wait until all the instances are up and running